### PR TITLE
use this if global is undefined

### DIFF
--- a/lib/assets/bundle.jst
+++ b/lib/assets/bundle.jst
@@ -40,4 +40,4 @@ var ${ exportName };
         ${ exportName } = buildBemXjst(${ globalDependencies });
         global['${ exportName }'] = ${ exportName };
     }
-})(typeof window !== "undefined" ? window : global);
+})(typeof window !== "undefined" ? window : global || this);


### PR DESCRIPTION
In case of V8 embed environment (example: Perl:V8 package) global object can be undefined.