### PR TITLE
Tests: fixed fs mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ym": "^0.1.2"
   },
   "scripts": {
+    "prepublish": "npm test",
     "pretest": "eslint . && jscs -c .jscs.js .",
     "test": "mocha -R spec",
     "cover": "istanbul cover _mocha",

--- a/test/techs/bemhtml.test.js
+++ b/test/techs/bemhtml.test.js
@@ -301,6 +301,9 @@ function build(templates, options) {
         });
     }
 
+    var bemhtmlPath = './node_modules/bem-xjst/lib/bemhtml/bundle.js'
+    scheme[bemhtmlPath] = require('fs').readFileSync(bemhtmlPath, 'utf8');
+
     mock(scheme);
 
     bundle = new MockNode('bundle');

--- a/test/techs/bemhtml.test.js
+++ b/test/techs/bemhtml.test.js
@@ -301,6 +301,7 @@ function build(templates, options) {
         });
     }
 
+    // mock for bemhtml.generate()
     var bemhtmlPath = './node_modules/bem-xjst/lib/bemhtml/bundle.js'
     scheme[bemhtmlPath] = require('fs').readFileSync(bemhtmlPath, 'utf8');
 

--- a/test/techs/bemtree.test.js
+++ b/test/techs/bemtree.test.js
@@ -213,6 +213,7 @@ function build(templates, options) {
         });
     }
 
+    // mock for bemhtml.generate()
     var bemtreePath = './node_modules/bem-xjst/lib/bemtree/bundle.js'
     scheme[bemtreePath] = require('fs').readFileSync(bemtreePath, 'utf8');
 

--- a/test/techs/bemtree.test.js
+++ b/test/techs/bemtree.test.js
@@ -213,6 +213,9 @@ function build(templates, options) {
         });
     }
 
+    var bemtreePath = './node_modules/bem-xjst/lib/bemtree/bundle.js'
+    scheme[bemtreePath] = require('fs').readFileSync(bemtreePath, 'utf8');
+
     mock(scheme);
 
     bundle = new MockNode('bundle');


### PR DESCRIPTION
Starting from bem-xjst v8.6.1 `require('bem-xjst').bemhtml` doesn’t contain all source code (as string) in private field. When `BEMHTML.generate()` execute we require bundle.js from FS.

Now: [require from FS](https://github.com/bem/bem-xjst/blob/0d9a27375b405d3103efcfc2a1033f7623606bf8/lib/compiler.js#L34-L36)

Before v8.6.1: [source definition](https://github.com/bem/bem-xjst/blob/v8.6.0/index.js#L12) and [source usage](https://github.com/bem/bem-xjst/blob/v8.6.0/lib/compiler.js#L30).